### PR TITLE
ttml2srt: add support for timestamp format in seconds.

### DIFF
--- a/hbogolib/ttml2srt.py
+++ b/hbogolib/ttml2srt.py
@@ -102,6 +102,13 @@ class Ttml2srt(object):
                       int(hhmmss[2]) * 1000]
         return self.scaler(hh + mm + ss + ms, scale)
 
+    def seconds_to_ms(self, time, scale=1):
+        ss, cc = time.rsplit('.', 1)
+        # Remove the unit signifier before converting to ms.
+        cc = int(cc[:-1]) * 10
+        ss = int(ss) * 1000
+        return self.scaler(ss + cc, scale)
+
     def get_sb_timestamp_be(self, time, shift=0, fps=23.976, tick_rate=None, scale=1):
         """Return SubRip timestamp after conversion from source timestamp.
         Assumes source timestamp to be in either the form of
@@ -117,6 +124,8 @@ class Ttml2srt(object):
         delim = ''.join([i for i in time if not i.isdigit()])[-1]
         if delim.lower() == 't':
             ms = self.ticks_to_ms(tick_rate, time, scale)
+        elif delim.lower() == 's':
+            ms = self.seconds_to_ms(time, scale);
         else:
             ms = self.timestamp_to_ms(time, fps, delim, scale)
 


### PR DESCRIPTION
This adds support for timestamp formats in the following format:

      <p begin="3.44s" xml:id="p0" end="5.0s">Michael Scott's Dunder<br />Mifflin Scranton</p>
      <p begin="5.12s" xml:id="p1" end="6.96s">Meredith Palmer Memorial</p>
      <p begin="7.08s" xml:id="p2" end="9.8s">Celebrity Rabies Awareness<br />Fun Run Race for the Cure.</p>
      <p begin="9.92s" xml:id="p3" end="11.4s">-This is Pam.<br />-Pro-Am.</p>
      <p begin="11.96s" xml:id="p4" end="14.08s">Pro-Am Race for the...<br />They hung up.</p>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Adding a new region/hbo go version
- [X] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


This is related to issue #22 and allows playback of the subtitles mentioned in that bug report. I did test other subtitles as well and nothing appears to be broken.
