### PR TITLE
Simplify and fix minute counting in ms to SRT conversion

### DIFF
--- a/hbogolib/ttml2srt.py
+++ b/hbogolib/ttml2srt.py
@@ -90,11 +90,11 @@ class Ttml2srt(object):
         return self.scaler(((1.0 / tickrate) * int(ticks.rstrip('t'))) * 1000, scale)
 
     def ms_to_subrip(self, ms):
-        return '{:02d}:{:02d}:{:02d},{:03d}'.format(
-            int(ms / (3600 * 1000)),  # hh
-            int(ms / 60000 - (ms / (3600 * 1000) * 60)),  # mm
-            int((ms % 60000) / 1000),  # ss
-            int((ms % 60000) % 1000))  # ms
+        hh = int(ms / 3.6e6)
+        mm = int((ms % 3.6e6) / 60000)
+        ss = int((ms % 60000) / 1000)
+        ms = int(ms % 1000)
+        return '{:02d}:{:02d}:{:02d},{:03d}'.format(hh, mm, ss, ms)
 
     def timestamp_to_ms(self, time, fps=23.976, delim='.', scale=1):
         hhmmss, frames = time.rsplit(delim, 1)


### PR DESCRIPTION
I was writing tests for *ttml2srt* to account for >1h timestamps after merging https://github.com/yuppity/ttml2srt/pull/2 and noticed there is still an issue in the ms to SRT timestamp conversion. This should fix it once and for all.

An alternative fix is to change https://github.com/arvvoid/plugin.video.hbogoeu/blob/79bc665c59d4c7ff37fd305adb0686faff0d41cf/hbogolib/ttml2srt.py#L95 to  

```python
int(ms / 60000 - (int(ms / (3600 * 1000)) * 60)),  # mm
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Adding a new region/hbo go version
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
