### PR TITLE
Optimize play links, use just content_id to avoid losing watched stat…

### DIFF
--- a/hbogolib/base.py
+++ b/hbogolib/base.py
@@ -155,8 +155,7 @@ class hbogo(object):
 
         elif mode == HbogoConstants.ACTION_PLAY:
             self.start()
-            self.handler.setDispCat(name)
-            self.handler.play(url, content_id)
+            self.handler.play(content_id)
 
         elif mode == HbogoConstants.ACTION_RESET_SETUP:  # logout, destry setup
             # ask confirm

--- a/hbogolib/handler.py
+++ b/hbogolib/handler.py
@@ -328,7 +328,7 @@ class HbogoHandler(object):
     def search(self):
         pass
 
-    def play(self, url, content_id):
+    def play(self, content_id):
         pass
 
     def procContext(self, action_type, content_id, optional=""):

--- a/hbogolib/handlereu.py
+++ b/hbogolib/handlereu.py
@@ -1004,7 +1004,7 @@ class HbogoHandler_eu(HbogoHandler):
         KodiUtil.endDir(self.handle, self.use_content_type)
 
     def play(self, content_id):
-        self.log("Play: " + str(content_id))
+        self.log("Initializing playback... " + str(content_id))
 
         if not self.chk_login():
             self.login()

--- a/hbogolib/handlereu.py
+++ b/hbogolib/handlereu.py
@@ -1003,8 +1003,8 @@ class HbogoHandler_eu(HbogoHandler):
 
         KodiUtil.endDir(self.handle, self.use_content_type)
 
-    def play(self, url, content_id):
-        self.log("Play: " + str(url))
+    def play(self, content_id):
+        self.log("Play: " + str(content_id))
 
         if not self.chk_login():
             self.login()
@@ -1282,11 +1282,9 @@ class HbogoHandler_eu(HbogoHandler):
                 plot = plot + ' ' + self.LB_EPISODE_UNTILL + ' ' + py2_encode(title['AvailabilityTo'])
 
         item_url = '%s?%s' % (self.base_url, urlencode({
-            'url': title['ObjectUrl'],
+            'url': 'PLAY',
             'mode': mode,
-            'name': filename,
-            'cid': cid,
-            'thumbnail': title['BackgroundUrl']
+            'cid': cid
         }))
 
         liz = xbmcgui.ListItem(name)

--- a/hbogolib/handlersp.py
+++ b/hbogolib/handlersp.py
@@ -352,8 +352,8 @@ class HbogoHandler_sp(HbogoHandler):
 
         KodiUtil.endDir(self.handle, self.use_content_type)
 
-    def play(self, url, content_id):
-        self.log("Play: " + str(url))
+    def play(self, content_id):
+        self.log("Play: " + str(content_id))
 
         if not self.chk_login():
             self.login()
@@ -364,7 +364,7 @@ class HbogoHandler_sp(HbogoHandler):
             self.logout()
             return
 
-        media_item = self.get_from_hbogo(url + self.LANGUAGE_CODE, 'xml')
+        media_item = self.get_from_hbogo(self.API_URL_BROWSE + content_id + self.LANGUAGE_CODE, 'xml')
 
         if self.lograwdata:
             self.log("Play Media: " + ET.tostring(media_item, encoding='utf8'))
@@ -540,9 +540,9 @@ class HbogoHandler_sp(HbogoHandler):
             media_type = "movie"
 
         item_url = '%s?%s' % (self.base_url, urlencode({
-            'url': title.find('link').text,
+            'url': 'PLAY',
             'mode': mode,
-            'name': name,
+            'cid': guid,
         }))
 
         thunb = self.get_thumbnail_url(title)

--- a/hbogolib/handlersp.py
+++ b/hbogolib/handlersp.py
@@ -353,7 +353,7 @@ class HbogoHandler_sp(HbogoHandler):
         KodiUtil.endDir(self.handle, self.use_content_type)
 
     def play(self, content_id):
-        self.log("Play: " + str(content_id))
+        self.log("Initializing playback... " + str(content_id))
 
         if not self.chk_login():
             self.login()


### PR DESCRIPTION
#82  Please check that your pull request pass this checks:

-  [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
-  [x] My code is both Python 2 and 3 compatible
-  [x] My code follows the code style of this project
-  [x] I made sure there wasn't another Pull Request opened for the same update/change
-  [x] I have successfully tested my changes locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-  [ ] Bug fix (non-breaking change which fixes an issue)
-  [ ] New feature (non-breaking change which adds functionality)
-  [x] Breaking change (fix or feature that would cause existing functionality to change)
-  [ ] Adding a new region/hbo go version

## Description:

Optimize play links, use just content_id to avoid losing watched status on API URL changes. Also maintain watched status consistency across different dirs. It will also preserve  Kodi watched status on loading content in different languages. 

This update will cause to lose current watched status, unfortunately, but will prevent that from happening in the future so this is a better choice long run. Better to make this change sooner than later.
