### PR TITLE
Add fix for Telekom Romania (My Account) login

### DIFF
--- a/hbogolib/constants.py
+++ b/hbogolib/constants.py
@@ -104,6 +104,23 @@ class HbogoConstants(object):
 
     SkylinkID = "c55e69f0-2471-46a9-a8b7-24dac54e6eb9"  # Skylink Operator ID, Skylink require special steps in login
 
+    # Special data for OAUTH that require custom actions
+    # each entry is one operator
+    # each operator has: 
+    #   id: the id of the operator for easy retrieval
+    #   confirm_uri: the URI that is called at a 2nd callback for auth success
+    #   payload: the data to send in this 2nd request
+    special_data = {
+        'telekom_ro': {
+            'id': "972706fe-094c-4ea5-ae98-e8c5d907f6a2",
+            'confirm_uri': "https://my.telekom.ro/oauth2/rest/approval",
+            'payload': {
+                'state': None,
+                'act': 1
+            }
+        }
+    }
+
     # 0 - operator website login form url, 1 - username field name, 2 - password field name, 3 form payload
     eu_redirect_login = {
         'c55e69f0-2471-46a9-a8b7-24dac54e6eb9': ['https://hbogo.skylink.cz/goauthenticate.aspx?client_id=HBO&redirect_uri=https%3a%2f%2fczapi.hbogo.eu%2foauthskylink%2frequest2.aspx&state=5zveHRYBaocYXvjTxHozRg&scope=HBO&response_type=code', 'txtLogin', 'txtPassword', {"__LASTFOCUS": None, "__EVENTTARGET": "btnSubmit", "__EVENTARGUMENT": None, "__VIEWSTATE": None, "__VIEWSTATEGENERATOR": None, "txtLogin": None, "txtPassword": None}],  # Czech Republic: Skylink + Slovakia: Skylink

--- a/hbogolib/handlereu.py
+++ b/hbogolib/handlereu.py
@@ -479,7 +479,7 @@ class HbogoHandler_eu(HbogoHandler):
             try:
                 # Treat special 2nd confirm callback required by Telekom RO
                 if self.op_id == HbogoConstants.special_data['telekom_ro']['id']:
-                    auth_state=parse.parse_qs(parsed_url.query)['state'][0]
+                    auth_state = parse.parse_qs(parsed_url.query)['state'][0]
 
                     confirm_payload = HbogoConstants.special_data['telekom_ro']['payload']
                     confirm_payload['state'] = auth_state

--- a/hbogolib/handlereu.py
+++ b/hbogolib/handlereu.py
@@ -477,6 +477,20 @@ class HbogoHandler_eu(HbogoHandler):
             self.log("PARTED URL: " + str(parsed_url))
 
             try:
+                # Treat special 2nd confirm callback required by Telekom RO
+                if self.op_id == HbogoConstants.special_data['telekom_ro']['id']:
+                    auth_state=parse.parse_qs(parsed_url.query)['state'][0]
+
+                    confirm_payload = HbogoConstants.special_data['telekom_ro']['payload']
+                    confirm_payload['state'] = auth_state
+                    confirm_response = cp_session.post(
+                        HbogoConstants.special_data['telekom_ro']['confirm_uri'], 
+                        confirm_payload
+                    )
+                    
+                    self.log("URL confirm: " + confirm_response.url)
+                    parsed_url = parse.urlparse(confirm_response.url)
+                
                 ssoid = parse.parse_qs(parsed_url.query)['ssoid'][0]
             except Exception:
                 self.log("OAuth login attempt failed, operator not supported, stack trace: " + traceback.format_exc())


### PR DESCRIPTION
## Please check that your pull request pass this checks:

-  [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
-  [x] My code is both Python 2 and 3 compatible
-  [x] My code follows the code style of this project
-  [x] I made sure there wasn't another Pull Request opened for the same update/change
-  [x] I have successfully tested my changes locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-  [x] Bug fix (non-breaking change which fixes an issue)
-  [ ] New feature (non-breaking change which adds functionality)
-  [ ] Breaking change (fix or feature that would cause existing functionality to change)
-  [ ] Adding a new region/hbo go version

## Description:
Login with Telekom Romania (My Account) uses OAUTH, but was not working because it required a 2nd 'confirm' callback to the Telekom service.
This fix adds this 2nd call (only for this operator, without affecting others), therefore removing the 'not supported' message at login.
Stores some needed constants in constants.py.
Login / play tested successfully.
Could be used to fix other operators that use a similar mechanisms.