### PR TITLE
Alternative season processing if parent node missing in series listing

### DIFF
--- a/hbogolib/handlereu.py
+++ b/hbogolib/handlereu.py
@@ -948,15 +948,7 @@ class HbogoHandler_eu(HbogoHandler):
                 self.n_seasons += 1
         except TypeError:
             self.log("Season listing: there is no parent node to extract seasons from. Trying alternative method.")
-            # This happens rarely and when it do its temporary within few hours to a a few days the item will return
-            # again correct data under the parent node from the api, but until it do this will load the first episode listed and
-            # try to pull season data from that listing as an alternative to retrive the seasons.
-            # If that fails as well will simply list episodes that are returned (better something then nothing).
-            # I was able to test this in the rare ocasion it occured and it worked.
-            # The next day the item was returning correct data again so this is an elusive event.
-            # But there is one log from a different user confirming the existence of the event.
-            # The next day the problem disapered by itself becouse the api started returning correct data under the parent node again.
-            # This implementation mitigate the event, the user won't notice anything, all will probably work as supposed thanks to this.
+            # Alternative way to get season listing if parent node is temporarily missing from the normal listing
             try:
                 jsonrsp2 = self.get_from_hbogo(jsonrsp['ChildContents']['Items'][0]['ObjectUrl'])
                 for season in jsonrsp2['Parent']['Parent']['ChildContents']['Items']:


### PR DESCRIPTION
## Please check that your pull request pass this checks:

-  [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
-  [x] My code is both Python 2 and 3 compatible
-  [x] My code follows the code style of this project (PEP8, long lines allowed if make sense)
-  [x] I made sure there wasn't another Pull Request opened for the same update/change
-  [x] I have successfully tested my changes locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-  [x] Bug fix (non-breaking change which fixes an issue)
-  [ ] New feature (non-breaking change which adds functionality)
-  [ ] Breaking change (fix or feature that would cause existing functionality to change)
-  [ ] Adding a new region/hbo go version

## Description:
This happens rarely and when it does its temporary within few hours to a few days the item will return again correct data under the parent node from the API, but until it does this will load the first episode listed and try to pull season data from that listing as an alternative way to retrieve the seasons.
If that fails as well will simply list episodes that are returned (better something then nothing).
 I was able to test this on one of the rare occasions it occurred and it worked.
The next day the item was returning correct data again so this is an elusive event.
But there is one log from a different user confirming the existence of the event.
The next day the problem disappeared by itself because the API started returning correct data under the parent node again.
This implementation mitigates the event, the user won't notice anything.

I was also able to test this by creating the conditions artificially, corrupting the parent node on purpose in the cache.