### PR TITLE
Show only full description if available

### DIFF
--- a/hbogolib/handlereu.py
+++ b/hbogolib/handlereu.py
@@ -1358,6 +1358,13 @@ class HbogoHandler_eu(HbogoHandler):
                 return list(votes) + [remove_mylist]
             return [add_mylist] + list(votes)
 
+    @staticmethod
+    def get_series_plot(title):
+        if 'Description' in title and title['Description'] is not None:
+            return py2_encode(title['Description'])
+
+        return py2_encode(title['Abstract'])
+
     def construct_media_info(self, title):
         plot = ""
         name = ""
@@ -1378,10 +1385,7 @@ class HbogoHandler_eu(HbogoHandler):
             scrapname = py2_encode(title['Name']) + " (" + str(title['ProductionYear']) + ")"
             if self.force_scraper_names:
                 name = scrapname
-            if 'Description' in title and title['Description'] is not None:
-                plot += py2_encode(title['Description'])
-            else:
-                plot += py2_encode(title['Abstract'])
+            plot = HbogoHandler_eu.get_series_plot(title)
         elif title['ContentType'] == 3:
             media_type = "episode"
             name = py2_encode(title['SeriesName']) + " - " + str(
@@ -1392,10 +1396,7 @@ class HbogoHandler_eu(HbogoHandler):
                 title['Tracking']['SeasonNumber']) + "E" + str(title['Tracking']['EpisodeNumber'])
             if self.force_scraper_names:
                 name = scrapname
-            if 'Description' in title and title['Description'] is not None:
-                plot += py2_encode(title['Description'])
-            else:
-                plot += py2_encode(title['Abstract'])
+            plot = HbogoHandler_eu.get_series_plot(title)
 
         img = title['BackgroundUrl']
 

--- a/hbogolib/handlereu.py
+++ b/hbogolib/handlereu.py
@@ -1378,6 +1378,7 @@ class HbogoHandler_eu(HbogoHandler):
             avail_datetime = Util.is_utc_datetime_past_now(availfrom)
             if avail_datetime is not True:
                 plot = py2_encode("[COLOR red]" + self.language(30009) + " [B]" + avail_datetime + "[/B][/COLOR] ")
+
         if title['ContentType'] == 1:  # 1=MOVIE/EXTRAS, 2=SERIES(serial), 3=SERIES(episode)
             name = py2_encode(title['Name'])
             if self.force_original_names:
@@ -1385,7 +1386,7 @@ class HbogoHandler_eu(HbogoHandler):
             scrapname = py2_encode(title['Name']) + " (" + str(title['ProductionYear']) + ")"
             if self.force_scraper_names:
                 name = scrapname
-            plot = HbogoHandler_eu.get_series_plot(title)
+            plot += HbogoHandler_eu.get_series_plot(title)
         elif title['ContentType'] == 3:
             media_type = "episode"
             name = py2_encode(title['SeriesName']) + " - " + str(
@@ -1396,7 +1397,7 @@ class HbogoHandler_eu(HbogoHandler):
                 title['Tracking']['SeasonNumber']) + "E" + str(title['Tracking']['EpisodeNumber'])
             if self.force_scraper_names:
                 name = scrapname
-            plot = HbogoHandler_eu.get_series_plot(title)
+            plot += HbogoHandler_eu.get_series_plot(title)
 
         img = title['BackgroundUrl']
 

--- a/hbogolib/handlereu.py
+++ b/hbogolib/handlereu.py
@@ -1378,10 +1378,10 @@ class HbogoHandler_eu(HbogoHandler):
             scrapname = py2_encode(title['Name']) + " (" + str(title['ProductionYear']) + ")"
             if self.force_scraper_names:
                 name = scrapname
-            plot += py2_encode(title['Abstract'])
-            if 'Description' in title:
-                if title['Description'] is not None:
-                    plot += py2_encode(title['Description'])
+            if 'Description' in title and title['Description'] is not None:
+                plot += py2_encode(title['Description'])
+            else:
+                plot += py2_encode(title['Abstract'])
         elif title['ContentType'] == 3:
             media_type = "episode"
             name = py2_encode(title['SeriesName']) + " - " + str(
@@ -1392,10 +1392,10 @@ class HbogoHandler_eu(HbogoHandler):
                 title['Tracking']['SeasonNumber']) + "E" + str(title['Tracking']['EpisodeNumber'])
             if self.force_scraper_names:
                 name = scrapname
-            plot += py2_encode(title['Abstract'])
-            if 'Description' in title:
-                if title['Description'] is not None:
-                    plot += py2_encode(title['Description'])
+            if 'Description' in title and title['Description'] is not None:
+                plot += py2_encode(title['Description'])
+            else:
+                plot += py2_encode(title['Abstract'])
 
         img = title['BackgroundUrl']
 


### PR DESCRIPTION
## Please check that your pull request pass this checks:

-  [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
-  [x] My code is both Python 2 and 3 compatible
-  [x] My code follows the code style of this project (PEP8, long lines allowed if make sense)
-  [x] I made sure there wasn't another Pull Request opened for the same update/change
-  [x] I have successfully tested my changes locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-  [x] Bug fix (non-breaking change which fixes an issue)
-  [ ] New feature (non-breaking change which adds functionality)
-  [ ] Breaking change (fix or feature that would cause existing functionality to change)
-  [ ] Adding a new region/hbo go version

## Description:
The "abstract" and the "description" are two very similar teaser about
the movie or series. Sometimes it's annoying to read the "abstract" then
read (almost) the same text when the description begins.

Instead of showing both the "abstract" and the "description", show only
"description" if available, and show only the "abstract" if no
description found.