### PR TITLE
Move from deprecated xbmc.translatePath to new xbmcvfs.translatePath

### DIFF
--- a/hbogolib/handler.py
+++ b/hbogolib/handler.py
@@ -113,7 +113,7 @@ class HbogoHandler(object):
         self.API_PLATFORM = 'COMP'
 
         self.log("Starting database connection...")
-        self.db = sqlite3.connect(xbmc.translatePath(self.addon.getAddonInfo('profile')) + 'hgo.db')
+        self.db = sqlite3.connect(KodiUtil.translatePath(self.addon.getAddonInfo('profile')) + 'hgo.db')
         cur = self.db.cursor()
         try:
             cur.execute("SELECT val_int FROM settings WHERE set_id='db_ver'")
@@ -222,11 +222,11 @@ class HbogoHandler(object):
 
     @staticmethod
     def get_resource(resourcefile):
-        return py2_decode(xbmc.translatePath(xbmcaddon.Addon().getAddonInfo('path') + '/resources/' + resourcefile))
+        return py2_decode(KodiUtil.translatePath(xbmcaddon.Addon().getAddonInfo('path') + '/resources/' + resourcefile))
 
     @staticmethod
     def get_media_resource(resourcefile):
-        return py2_decode(xbmc.translatePath(xbmcaddon.Addon().getAddonInfo('path') + '/resources/media/' + resourcefile))
+        return py2_decode(KodiUtil.translatePath(xbmcaddon.Addon().getAddonInfo('path') + '/resources/media/' + resourcefile))
 
     def log(self, msg, level=xbmc.LOGDEBUG):
         try:
@@ -395,7 +395,7 @@ class HbogoHandler(object):
 
     def del_login(self):
         try:
-            folder = xbmc.translatePath(self.addon.getAddonInfo('profile'))
+            folder = KodiUtil.translatePath(self.addon.getAddonInfo('profile'))
             self.log("Removing stored session: " + folder + self.addon_id + "_session" + ".ecdata")
             os.remove(folder + self.addon_id + "_session" + ".ecdata")
         except Exception:
@@ -415,7 +415,7 @@ class HbogoHandler(object):
         self.log("Removed stored setup")
 
     def save_obj(self, obj, name):
-        folder = xbmc.translatePath(self.addon.getAddonInfo('profile'))
+        folder = KodiUtil.translatePath(self.addon.getAddonInfo('profile'))
         self.log("Saving: " + folder + name + '.ecdata')
         with open(folder + name + '.ecdata', 'wb') as f:
             try:
@@ -424,7 +424,7 @@ class HbogoHandler(object):
                 f.write(bytes(self.encrypt_credential_v1(json.dumps(obj)), 'utf8'))
 
     def load_obj(self, name):
-        folder = xbmc.translatePath(self.addon.getAddonInfo('profile'))
+        folder = KodiUtil.translatePath(self.addon.getAddonInfo('profile'))
         self.log("Trying to load: " + folder + name + '.ecdata')
         try:
             with open(folder + name + '.ecdata', 'rb') as f:

--- a/hbogolib/handlereu.py
+++ b/hbogolib/handlereu.py
@@ -1174,7 +1174,7 @@ class HbogoHandler_eu(HbogoHandler):
             list_item.setProperty('inputstream.adaptive.license_key', license_key)
 
             #  inject subtitles for the EU region, workaround to avoid the sometimes disappearing internal subtitles defined in the manifest
-            folder = xbmc.translatePath(self.addon.getAddonInfo('profile'))
+            folder = KodiUtil.translatePath(self.addon.getAddonInfo('profile'))
             folder = folder + 'subs' + os.sep + content_id + os.sep
             if self.addon.getSetting('forcesubs') == 'true':
                 #  if inject subtitles is enable cache direct subtitle links if available and set subtitles from cache

--- a/hbogolib/handlersp.py
+++ b/hbogolib/handlersp.py
@@ -434,7 +434,7 @@ class HbogoHandler_sp(HbogoHandler):
             li.setProperty('inputstream.adaptive.license_key', license_url)
 
             # GET SUBTITLES
-            folder = xbmc.translatePath(self.addon.getAddonInfo('profile'))
+            folder = KodiUtil.translatePath(self.addon.getAddonInfo('profile'))
             folder = folder + 'subs' + os.sep + media_guid + os.sep
             if self.addon.getSetting('forcesubs') == 'true':
                 self.log("Cache subtitles enabled, downloading and converting subtitles in: " + folder)

--- a/libs/kodiutil.py
+++ b/libs/kodiutil.py
@@ -5,10 +5,22 @@
 
 from __future__ import absolute_import, division
 
+import sys
+
 from kodi_six import xbmcplugin  # type: ignore
+
+# import for translate path
+if sys.version_info < (3, 0):  # for Kodi 18 use old translatePath
+    from kodi_six import xbmc as kodipath  # type: ignore
+else:  # for Kodi 19+ use new translatePath
+    from kodi_six import xbmcvfs as kodipath  # type: ignore
 
 
 class KodiUtil(object):
+
+    @staticmethod
+    def translatePath(path):
+        return kodipath.translatePath(path)
 
     @staticmethod
     def addSorting(handle, use_content_type):


### PR DESCRIPTION
## Please check that your pull request pass this checks:

-  [x] My changes respect the [Kodi add-on development rules](https://kodi.wiki/view/Add-on_rules)
-  [x] My code is both Python 2 and 3 compatible
-  [x] My code follows the code style of this project (PEP8, long lines allowed if make sense)
-  [x] I made sure there wasn't another Pull Request opened for the same update/change
-  [x] I have successfully tested my changes locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-  [x] Bug fix (non-breaking change which fixes an issue)
-  [ ] New feature (non-breaking change which adds functionality)
-  [ ] Breaking change (fix or feature that would cause existing functionality to change)
-  [ ] Adding a new region/hbo go version

## Description:

Move from deprecated xbmc.translatePath to new xbmcvfs.translatePath for Kodi 19+
